### PR TITLE
Update to Julia 1.1

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,58 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[Strided]]
+deps = ["LinearAlgebra", "TupleTools"]
+git-tree-sha1 = "b929f81ca5e78362a4c1e935bb5e7bee27dc2279"
+uuid = "5e0ebb24-38b0-5f93-81fe-25c709ecae67"
+version = "0.3.1"
+
+[[TensorOperations]]
+deps = ["LinearAlgebra", "Random", "Strided", "Test", "TupleTools"]
+git-tree-sha1 = "7cd4a4404c851e8ef8f26bd3c3569bec5130ddec"
+uuid = "6aa20fa7-93e2-5fca-9bc0-fbd0db3c71a2"
+version = "1.0.4"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[TupleTools]]
+deps = ["Random", "Test"]
+git-tree-sha1 = "b006524003142128cc6d36189dce337729aa0050"
+uuid = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
+version = "1.1.0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,14 @@
+name = "NCon"
+uuid = "609bbe1a-2e47-5e4f-9dfa-53072e72054c"
+authors = ["Markus Hauru <markus@mhauru.org>"]
+version = "0.1.0"
+
+[deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+TensorOperations = "6aa20fa7-93e2-5fca-9bc0-fbd0db3c71a2"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.4
+julia 1.0
 TensorOperations

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using NCon
-using Base.Test
+using Test
 using TensorOperations
 
 A = rand(3,2,5)
@@ -75,10 +75,9 @@ con = ncon(E, [1,2,1,2]; check_indices=true)
 @test isapprox(con, reco)
 
 con = ncon((I,J), ([1,2], [-2,2,1,-1]); check_indices=true)
-reco = tensorcontract(I, [:i,:j], J, [:b,:j,:i,:a], [:a,:b]; method=:native)
+reco = tensorcontract(I, [:i,:j], J, [:b,:j,:i,:a], [:a,:b])
 @test isapprox(con, reco)
 
 con = ncon(J, [1,-1,-2,1]; check_indices=true)
 @tensor reco[a,b] := J[i,a,b,i]
 @test isapprox(con, reco)
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -81,3 +81,11 @@ reco = tensorcontract(I, [:i,:j], J, [:b,:j,:i,:a], [:a,:b])
 con = ncon(J, [1,-1,-2,1]; check_indices=true)
 @tensor reco[a,b] := J[i,a,b,i]
 @test isapprox(con, reco)
+
+# test whether it works for non-blastypes
+A = Float16.(A)
+B = Float16.(B)
+C = Float16.(C)
+con = ncon((A, B, C), ((-1,1,2), (2,-2), (-4,1,3,-3,3)); check_indices=true)
+@tensor reco[a,b,c,d] := A[a,k,j] * B[j,b] * C[d,k,i,c,i]
+@test isapprox(con, reco)


### PR DESCRIPTION
This is a minimally invasive update of the package to Julia 1.1. All tests pass and I added one to check that the changed way that non-blasfloats are treated in `TensorOperations.jl` works correctly.